### PR TITLE
Fix missing version in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[build-system]
+requires = ["setuptools>=45"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gnomad-constraint"
+version = "0.1.0"
+requires-python = ">=3.9"
+
 [tool.setuptools.packages.find]
 include = ["gnomad_constraint*"]
 


### PR DESCRIPTION
Cursor-generated fix for this CI error: https://github.com/broadinstitute/gnomad-constraint/pull/52#issuecomment-4164362782